### PR TITLE
fix typo in index.html again

### DIFF
--- a/service-worker-lab/app/index.html
+++ b/service-worker-lab/app/index.html
@@ -42,7 +42,7 @@ limitations under the License.
       (function() {
         'use strict';
 
-        // TODO - 2: Regsiter the service worker
+        // TODO - 2: Register the service worker
 
       })();
     </script>


### PR DESCRIPTION
This pull request fixes a typo in index.html.  I noticed that it was originally fixed by @penance316 but on a subsequent merge by @DavidScales it was changed back to the original typo.

Just thought I'd try my hand at a PR for the first time with this simple change.  Thanks!