### PR TITLE
refactor(Lighthouse lab): Load roboto over https instead of http

### DIFF
--- a/lighthouse-lab/app/index.html
+++ b/lighthouse-lab/app/index.html
@@ -23,7 +23,7 @@ limitations under the License.
 
   <title>My responsive blog: picture story</title>
 
-  <link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="css/main.css" />
 
   <!-- TODO 4.1: Add manifest.json -->

--- a/lighthouse-lab/solution/index.html
+++ b/lighthouse-lab/solution/index.html
@@ -23,7 +23,7 @@ limitations under the License.
 
   <title>My responsive blog: picture story</title>
 
-  <link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="css/main.css" />
 
   <!-- Web Application Manifest -->

--- a/lighthouse-lab/solution/service-worker.js
+++ b/lighthouse-lab/solution/service-worker.js
@@ -21,7 +21,7 @@ self.addEventListener('install', function(event) {
         '.',
         'index.html',
         'css/main.css',
-        'http://fonts.googleapis.com/css?family=Roboto:300,400,500,700',
+        'https://fonts.googleapis.com/css?family=Roboto:300,400,500,700',
         'images/still_life-1600_large_2x.jpg',
         'images/still_life-800_large_1x.jpg',
         'images/still_life_medium.jpg',


### PR DESCRIPTION
Fixes the mixed content error.

[This page (point 5.2)](https://google-developer-training.gitbooks.io/progressive-web-apps-ilt-codelabs/content/docs/lab_auditing_with_lighthouse.html) of the documentation should be updated aswell but I don't think it's being generated from this repo or at least I could not find it.

