### PR TITLE
Fixing assertion messages for getOrders tests

### DIFF
--- a/indexed-db-lab/app/test/test.html
+++ b/indexed-db-lab/app/test/test.html
@@ -167,15 +167,15 @@ limitations under the License.
           if (idbApp.getOrders()) {
             idbApp.getOrders().then(function(orders) {
               if (orders.length > 0) {
-                assert.ok(true, 'getByName function working');
+                assert.ok(true, 'getOrders function working');
                 done();
               } else {
-                assert.ok(false, 'getByName returning empty array');
+                assert.ok(false, 'getOrders returning empty array');
                 done();
               }
             });
           } else {
-            assert.ok(false, 'getByName not returning anything');
+            assert.ok(false, 'getOrders not returning anything');
             done();
           }
         } else {


### PR DESCRIPTION
Assertion messages were referring to getByName.