### PR TITLE
doc(*): remove references to GitBook

### DIFF
--- a/amp-pwa-lab/README.md
+++ b/amp-pwa-lab/README.md
@@ -11,7 +11,7 @@ You'll also get a chance to use [Workbox](https://workboxjs.org/).
 
 ## Getting started
 
-Instructions, as well as lecture videos and related content, are available on [developers.google.com](https://developers.google.com/web/ilt/pwa/). The instructions can also be accessed on [GitBook](https://www.gitbook.com/book/google-developer-training/progressive-web-apps-ilt-codelabs/details), where they are available as a [downloadable PDF](https://www.gitbook.com/download/pdf/book/google-developer-training/progressive-web-apps-ilt-codelabs).
+Instructions, as well as lecture videos and related content, are available on [developers.google.com](https://developers.google.com/web/ilt/pwa/).
 
 ## More resources
 

--- a/demos/authentication/README.md
+++ b/demos/authentication/README.md
@@ -3,8 +3,7 @@
 This sample application can be used to demonstrate how to implement client-side
 Google sign-in.
 
-This content is part of Google's [Progressive Web App Training](https://developers.google.com/web/ilt/pwa/),
-which is also available on [GitBook](https://www.gitbook.com/book/google-developer-training/progressive-web-apps-ilt-codelabs/details).
+This content is part of Google's [Progressive Web App Training](https://developers.google.com/web/ilt/pwa/).
 
 ## Note
 

--- a/demos/service-worker-debug/README.md
+++ b/demos/service-worker-debug/README.md
@@ -3,8 +3,7 @@
 This sample application can be used to demonstrate techniques for debugging
 service workers.
 
-This content is part of Google's [Progressive Web App Training](https://developers.google.com/web/ilt/pwa/),
-which is also available on [GitBook](https://www.gitbook.com/book/google-developer-training/progressive-web-apps-ilt-codelabs/details). 
+This content is part of Google's [Progressive Web App Training](https://developers.google.com/web/ilt/pwa/).
 
 ## Note
 

--- a/fetch-api-lab/README.md
+++ b/fetch-api-lab/README.md
@@ -4,9 +4,7 @@ In this lab you learn how to use the Fetch API, a simple interface for fetching 
 
 ## Getting started
 
-To get started, check out the instructions in
-[GitBook](https://google-developer-training.gitbooks.io/progressive-web-apps-ilt-codelabs/content/docs/lab_fetch_api.html)
-or on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-fetch-api).
+To get started, check out the instructions on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-fetch-api).
 
 ## Note
 

--- a/google-analytics-lab/README.md
+++ b/google-analytics-lab/README.md
@@ -6,9 +6,7 @@ in service workers and how to use offline analytics.
 
 ## Getting started
 
-To get started, check out the instructions in
-[GitBook](https://google-developer-training.gitbooks.io/progressive-web-apps-ilt-codelabs/content/docs/lab_integrating_analytics.html)
-or on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-integrating-analytics).
+To get started, check out the instructions on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-integrating-analytics).
 
 ## Note
 

--- a/offline-quickstart-lab/README.md
+++ b/offline-quickstart-lab/README.md
@@ -6,9 +6,7 @@ You also learn how to add offline functionality to a website.
 
 ## Getting started
 
-To get started, check out the instructions in
-[GitBook](https://google-developer-training.gitbooks.io/progressive-web-apps-ilt-codelabs/content/docs/lab_offline_quickstart.html)
-or on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-offline-quickstart).
+To get started, check out the instructions on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-offline-quickstart).
 
 ## Note
 

--- a/push-notification-lab/README.md
+++ b/push-notification-lab/README.md
@@ -6,9 +6,7 @@ from a Node.js server.
 
 ## Getting started
 
-To get started, check out the instructions in
-[GitBook](https://google-developer-training.gitbooks.io/progressive-web-apps-ilt-codelabs/content/docs/lab_integrating_web_push.html)
-or on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-integrating-web-push).
+To get started, check out the instructions on [developers.google.com](https://developers.google.com/web/ilt/pwa/lab-integrating-web-push).
 
 ## Note
 


### PR DESCRIPTION
This commit removes documentation links to GitBook instructions,
which are no longer available.